### PR TITLE
Fix build problems on latest CUDA version

### DIFF
--- a/submodules/diff-gaussian-rasterization-softmax/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-gaussian-rasterization-softmax/cuda_rasterizer/rasterizer_impl.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <vector>
 #include "rasterizer.h"

--- a/submodules/simple-knn/simple_knn.cu
+++ b/submodules/simple-knn/simple_knn.cu
@@ -11,6 +11,7 @@
 
 #define BOX_SIZE 1024
 
+#include <float.h>
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 #include "simple_knn.h"


### PR DESCRIPTION
I was having some build errors due to missing types when I compiled on CUDA 12.6.3 with the latest torch.  These changed fixed the issue and I'm happy to report SparseGS runs great.

I actually did this in a docker container.  I noticed there isn't one in the repo.  I'd be happy to share my dockerfile with you so that others can easily use this great library.  